### PR TITLE
Containers network configuration were changed

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.1] - upcoming release
+## [2.3.1] - upcoming release
 
 ### Changed
 
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Livereload configuration on ports `35729` and `35730`. Use this  simple [Live Reload](https://chrome.google.com/webstore/detail/live-reload/jcejoncdonagmfohjcdgohnmecaipidc) extension instead.
 
+## [2.3.0] - 2021-07-28
+
+### Changed
+
+- `network_mode: bridge` was changed to internal Docker network `infrastructure_network`
 
 ## [2.2.0] - 2021-04-22
 

--- a/local_infrastructure/docker-compose.yml
+++ b/local_infrastructure/docker-compose.yml
@@ -16,6 +16,11 @@ volumes:
   mariadb104_volume:
     name: MariaDB104-Volume
 
+networks:
+  infrastructure_network:
+    external:
+      name: infrastructure_network
+
 services:
   reverse-proxy:
     image: traefik:v2.2
@@ -37,7 +42,8 @@ services:
     restart: always
     labels:
       - traefik.enable=false
-    network_mode: bridge
+    networks:
+      - infrastructure_network
     ports:
       - 3356:3306
     environment:
@@ -53,7 +59,8 @@ services:
     restart: always
     labels:
       - traefik.enable=false
-    network_mode: bridge
+    networks:
+      - infrastructure_network
     ports:
       - 3357:3306
     environment:
@@ -69,7 +76,8 @@ services:
     restart: always
     labels:
       - traefik.enable=false
-    network_mode: bridge
+    networks:
+      - infrastructure_network
     ports:
       - 3380:3306
     environment:
@@ -86,7 +94,8 @@ services:
     restart: always
     labels:
       - traefik.enable=false
-    network_mode: bridge
+    networks:
+      - infrastructure_network
     ports:
       - 33101:3306
     environment:
@@ -103,7 +112,8 @@ services:
     restart: always
     labels:
       - traefik.enable=false
-    network_mode: bridge
+    networks:
+      - infrastructure_network
     ports:
       - 33102:3306
     environment:
@@ -120,7 +130,8 @@ services:
     restart: always
     labels:
       - traefik.enable=false
-    network_mode: bridge
+    networks:
+      - infrastructure_network
     ports:
       - 33103:3306
     environment:
@@ -137,7 +148,8 @@ services:
     restart: always
     labels:
       - traefik.enable=false
-    network_mode: bridge
+    networks:
+      - infrastructure_network
     ports:
       - 33104:3306
     environment:
@@ -155,7 +167,8 @@ services:
       - traefik.enable=true
       - traefik.http.routers.phpmyadmin-http.rule=Host(`phpmyadmin.docker.local`)
       - traefik.http.routers.phpmyadmin-http.entrypoints=http
-    network_mode: bridge
+    networks:
+      - infrastructure_network
     depends_on:
       - reverse-proxy
       - mysql56
@@ -185,7 +198,8 @@ services:
     container_name: mailhog
     image: mailhog/mailhog:v1.0.1
     restart: always
-    network_mode: bridge
+    networks:
+      - infrastructure_network
     ports:
       - 1025:1025
       - 8025:8025

--- a/local_infrastructure/migration/update-2.3.sh
+++ b/local_infrastructure/migration/update-2.3.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+docker network create infrastructure_network
+
+cd ${PROJECTS_ROOT_DIR}docker_infrastructure/local_infrastructure/ || exit
+docker-compose up -d --force-recreate

--- a/templates/project/docker-compose.yml
+++ b/templates/project/docker-compose.yml
@@ -7,6 +7,12 @@
 # For MacOS users (development only)
 # $ docker-sync-stack start
 version: '3.7'
+
+networks:
+  infrastructure:
+    external:
+      name: infrastructure_network
+
 services:
   php-apache:
     container_name: example.com
@@ -51,7 +57,8 @@ services:
     external_links:
       - mysql57:mysql
       - mailhog
-    network_mode: bridge
+    networks:
+      - infrastructure
     environment:
       - COMPOSER_VERSION=2
       # Must be set to some of the domains for xdebug to work. Should have server configured in
@@ -74,14 +81,16 @@ services:
 
 #  redis:
 #    image: redis:latest
-#    network_mode: bridge
+#    networks:
+#      - infrastructure
 #    labels:
 #      - traefik.enable=false
 #    restart: always
 
 #  memcached:
 #    image: 'memcached:1.5'
-#    network_mode: bridge
+#    networks:
+#      - infrastructure
 #    labels:
 #      - traefik.enable=false
 #    restart: always
@@ -100,4 +109,5 @@ services:
 #        soft: -1
 #        hard: -1
 #    restart: always
-#    network_mode: bridge
+#    networks:
+#      - infrastructure


### PR DESCRIPTION
Good Day, @maksymz 

The infrastructure network configuration was changed. We will not use bridge mode anymore, better implementation with an internal network is required.
We will use this to have the ability to break circle dependencies between containers in the case when we want to use Varnish.

Please keep in mind that this pull request cannot be merged without a dockerizer update, the same changes are required there.

Best Regards,
Serhii.