### PR TITLE
Heimdall dashboard for the local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 .idea/*
 /local_infrastructure/configuration/certificates.toml
+/local_infrastructure/dashboard/*
+!/local_infrastructure/dashboard/.gitkeep

--- a/local_infrastructure/docker-compose.yml
+++ b/local_infrastructure/docker-compose.yml
@@ -28,6 +28,21 @@ services:
       - ./configuration/:/configuration/
       - ${SSL_CERTIFICATES_DIR}:/certs/
 
+  dashboard:
+    image: linuxserver/heimdall:2.4.13
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Europe/Kyiv
+    volumes:
+      - ./dashboard:/config
+    network_mode: bridge
+    restart: unless-stopped
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.dashboard-http.rule=Host(`dashboard.local`)
+      - traefik.http.routers.dashboard-http.entrypoints=http
+
   mysql56:
     container_name: mysql56
     image: mysql:5.6


### PR DESCRIPTION
Greetings.

Glad to share the fantastic service that I found.
This is Heimdall, a service that is a simple dashboard with fast access to any applications, local and remote, and with considerable customization potential.
For example, I set a new tab of my browser to open this dashboard instead of the browser default page. And on my personal dashboard, I can access all services that I need, like Traefik dashboard or PhphMyAdmin.
Also, it is possible to create tags for projects and has fast access to the project webpages, etc...

![Selection_641](https://user-images.githubusercontent.com/57250120/180796355-0785ed9e-4756-49c9-92c3-9789866d28b5.png)

![Heimdall_Screenshot](https://user-images.githubusercontent.com/57250120/180796675-37346886-6ea8-4c54-b32d-76ba48f1213c.png)

Have a nice day,
Serhii.